### PR TITLE
Use upper case column names

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -284,8 +284,12 @@ Instance.prototype.set = function(key, value, options) {
         }
 
         for (i = 0, length = keys.length; i < length; i++) {
-          if (values[keys[i]] !== undefined) {
-            this.set(keys[i], values[keys[i]], options);
+          //If all column names in results are Upper Case, use Upper Case key value
+          var val = values[keys[i]] ? values[keys[i]]: values[keys[i].toUpperCase()];
+          //if (values[keys[i]] !== undefined) {
+          if (val) {
+            //this.set(keys[i], values[keys[i]], options);
+            this.set(keys[i], val, options);
           }
         }
       } else {
@@ -978,7 +982,7 @@ Instance.prototype.decrement = function(fields, options) {
  */
 Instance.prototype.equals = function(other) {
   var result = true;
-  
+
   if (!other || !other.dataValues) {
     return false;
   }


### PR DESCRIPTION
In case of a table created with columns in upper case mode, the query
results are always upper case.
